### PR TITLE
Use standalone Alertmanager chart and Node Exporter's SA config fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [helm_release.alertmanager](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.kube_state_metrics](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.node_exporter](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.prometheus](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
@@ -34,37 +35,25 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_alert_relabel_configs"></a> [alert\_relabel\_configs](#input\_alert\_relabel\_configs) | Adds option to add alert\_relabel\_configs to avoid duplicate alerts in alertmanager useful in H/A prometheus with different external labels but the same alerts | `map` | `{}` | no |
 | <a name="input_alertmanager_affinity"></a> [alertmanager\_affinity](#input\_alertmanager\_affinity) | Affinity for alertmanager pods | `map` | `{}` | no |
 | <a name="input_alertmanager_annotations"></a> [alertmanager\_annotations](#input\_alertmanager\_annotations) | Annotations for Alertmanager pods | `map` | `{}` | no |
-| <a name="input_alertmanager_base_url"></a> [alertmanager\_base\_url](#input\_alertmanager\_base\_url) | External URL which can access alertmanager | `string` | `"/"` | no |
-| <a name="input_alertmanager_config_file_name"></a> [alertmanager\_config\_file\_name](#input\_alertmanager\_config\_file\_name) | The configuration file name to be loaded to alertmanager Must match the key within configuration loaded from ConfigMap/Secret | `string` | `"alertmanager.yml"` | no |
-| <a name="input_alertmanager_config_from_secret"></a> [alertmanager\_config\_from\_secret](#input\_alertmanager\_config\_from\_secret) | The name of a secret in the same kubernetes namespace which contains the Alertmanager config Defining configFromSecret will cause templates/alertmanager-configmap.yaml to NOT generate a ConfigMap resource | `string` | `""` | no |
-| <a name="input_alertmanager_config_map_override_name"></a> [alertmanager\_config\_map\_override\_name](#input\_alertmanager\_config\_map\_override\_name) | ConfigMap override where fullname is {{.Release.Name}}-{{.Values.alertmanager.configMapOverrideName} Defining configMapOverrideName will cause templates/alertmanager-configmap.yaml to NOT generate a ConfigMap resource | `string` | `""` | no |
-| <a name="input_alertmanager_enable"></a> [alertmanager\_enable](#input\_alertmanager\_enable) | Enable Alert manager | `string` | `"true"` | no |
+| <a name="input_alertmanager_chart_name"></a> [alertmanager\_chart\_name](#input\_alertmanager\_chart\_name) | Helm Alertmanager chart name to provision | `string` | `"alertmanager"` | no |
+| <a name="input_alertmanager_chart_namespace"></a> [alertmanager\_chart\_namespace](#input\_alertmanager\_chart\_namespace) | Namespace to install the Alertmanager chart into | `string` | `"default"` | no |
+| <a name="input_alertmanager_chart_repository"></a> [alertmanager\_chart\_repository](#input\_alertmanager\_chart\_repository) | Helm repository for the Alertmanager chart | `string` | `"https://prometheus-community.github.io/helm-charts"` | no |
+| <a name="input_alertmanager_chart_version"></a> [alertmanager\_chart\_version](#input\_alertmanager\_chart\_version) | Version of Alertmanager chart to install. Set to empty to install the latest version | `string` | `""` | no |
+| <a name="input_alertmanager_config"></a> [alertmanager\_config](#input\_alertmanager\_config) | Additional ConfigMap entries for Alertmanager in YAML string | `string` | `"global: {}\n  # slack_api_url: ''\n\ntemplates:\n  - '/etc/alertmanager/*.tmpl'\n\nreceivers:\n  - name: default-receiver\n    # slack_configs:\n    #  - channel: '@you'\n    #    send_resolved: true\n\nroute:\n  group_wait: 10s\n  group_interval: 5m\n  receiver: default-receiver\n  repeat_interval: 3h\n"` | no |
+| <a name="input_alertmanager_enable"></a> [alertmanager\_enable](#input\_alertmanager\_enable) | Enable Alertmanager | `string` | `"true"` | no |
 | <a name="input_alertmanager_extra_args"></a> [alertmanager\_extra\_args](#input\_alertmanager\_extra\_args) | Extra arguments for Alertmanager container | `map` | `{}` | no |
-| <a name="input_alertmanager_extra_env"></a> [alertmanager\_extra\_env](#input\_alertmanager\_extra\_env) | Extra environment variables for Alertmanager container | `map` | `{}` | no |
-| <a name="input_alertmanager_extra_secret_mounts"></a> [alertmanager\_extra\_secret\_mounts](#input\_alertmanager\_extra\_secret\_mounts) | Defines additional mounts with secrets. Secrets must be manually created in the namespace. | `list` | `[]` | no |
-| <a name="input_alertmanager_files"></a> [alertmanager\_files](#input\_alertmanager\_files) | Additional ConfigMap entries for Alertmanager in YAML string | `string` | `"alertmanager.yml:\n  global: {}\n    # slack_api_url: ''\n\n  receivers:\n    - name: default-receiver\n      # slack_configs:\n      #  - channel: '@you'\n      #    send_resolved: true\n\n  route:\n    group_wait: 10s\n    group_interval: 5m\n    receiver: default-receiver\n    repeat_interval: 3h\n"` | no |
-| <a name="input_alertmanager_headless_annotations"></a> [alertmanager\_headless\_annotations](#input\_alertmanager\_headless\_annotations) | Annotations for alertmanager StatefulSet headless service | `map` | `{}` | no |
-| <a name="input_alertmanager_headless_labels"></a> [alertmanager\_headless\_labels](#input\_alertmanager\_headless\_labels) | Labels for alertmanager StatefulSet headless service | `map` | `{}` | no |
 | <a name="input_alertmanager_ingress_annotations"></a> [alertmanager\_ingress\_annotations](#input\_alertmanager\_ingress\_annotations) | Annotations for Alertmanager ingress | `map` | `{}` | no |
 | <a name="input_alertmanager_ingress_enabled"></a> [alertmanager\_ingress\_enabled](#input\_alertmanager\_ingress\_enabled) | Enable ingress for Alertmanager | `string` | `"false"` | no |
-| <a name="input_alertmanager_ingress_extra_labels"></a> [alertmanager\_ingress\_extra\_labels](#input\_alertmanager\_ingress\_extra\_labels) | Additional labels for Alertmanager ingress | `map` | `{}` | no |
 | <a name="input_alertmanager_ingress_hosts"></a> [alertmanager\_ingress\_hosts](#input\_alertmanager\_ingress\_hosts) | List of Hosts for Alertmanager ingress | `list` | `[]` | no |
 | <a name="input_alertmanager_ingress_tls"></a> [alertmanager\_ingress\_tls](#input\_alertmanager\_ingress\_tls) | TLS configurationf or Alertmanager ingress | `list` | `[]` | no |
 | <a name="input_alertmanager_node_selector"></a> [alertmanager\_node\_selector](#input\_alertmanager\_node\_selector) | Node selector for alertmanager pods | `map` | `{}` | no |
-| <a name="input_alertmanager_pdb_enable"></a> [alertmanager\_pdb\_enable](#input\_alertmanager\_pdb\_enable) | Enable PDB | `bool` | `true` | no |
-| <a name="input_alertmanager_pdb_max_unavailable"></a> [alertmanager\_pdb\_max\_unavailable](#input\_alertmanager\_pdb\_max\_unavailable) | Max unavailable pods for Alertmanager | `number` | `1` | no |
-| <a name="input_alertmanager_pod_security_policy_annotations"></a> [alertmanager\_pod\_security\_policy\_annotations](#input\_alertmanager\_pod\_security\_policy\_annotations) | PodSecurityPolicy annotations for alertmanager | `map` | <pre>{<br>  "apparmor.security.beta.kubernetes.io/allowedProfileNames": "runtime/default",<br>  "apparmor.security.beta.kubernetes.io/defaultProfileName": "runtime/default",<br>  "seccomp.security.alpha.kubernetes.io/allowedProfileNames": "docker/default,runtime/default",<br>  "seccomp.security.alpha.kubernetes.io/defaultProfileName": "runtime/default"<br>}</pre> | no |
-| <a name="input_alertmanager_prefix_url"></a> [alertmanager\_prefix\_url](#input\_alertmanager\_prefix\_url) | The URL prefix at which the container can be accessed. Useful in the case the '-web.external-url' includes a slug so that the various internal URLs are still able to access as they are in the default case. | `string` | `""` | no |
-| <a name="input_alertmanager_priority_class_name"></a> [alertmanager\_priority\_class\_name](#input\_alertmanager\_priority\_class\_name) | Priority Class Name for Alertmanager pods | `string` | `""` | no |
 | <a name="input_alertmanager_pull_policy"></a> [alertmanager\_pull\_policy](#input\_alertmanager\_pull\_policy) | Image pull policy for Alertmanager | `string` | `"IfNotPresent"` | no |
 | <a name="input_alertmanager_pv_access_modes"></a> [alertmanager\_pv\_access\_modes](#input\_alertmanager\_pv\_access\_modes) | alertmanager data Persistent Volume access modes | `list` | <pre>[<br>  "ReadWriteOnce"<br>]</pre> | no |
-| <a name="input_alertmanager_pv_annotations"></a> [alertmanager\_pv\_annotations](#input\_alertmanager\_pv\_annotations) | Annotations for Alertmanager PV | `map` | `{}` | no |
 | <a name="input_alertmanager_pv_enabled"></a> [alertmanager\_pv\_enabled](#input\_alertmanager\_pv\_enabled) | Enable persistent volume on Alertmanager | `string` | `"true"` | no |
-| <a name="input_alertmanager_pv_existing_claim"></a> [alertmanager\_pv\_existing\_claim](#input\_alertmanager\_pv\_existing\_claim) | Use an existing PV claim for alertmanager | `string` | `""` | no |
 | <a name="input_alertmanager_pv_size"></a> [alertmanager\_pv\_size](#input\_alertmanager\_pv\_size) | alertmanager data Persistent Volume size | `string` | `"2Gi"` | no |
+| <a name="input_alertmanager_release_name"></a> [alertmanager\_release\_name](#input\_alertmanager\_release\_name) | Helm release name for Alertmanager | `string` | `"alertmanager"` | no |
 | <a name="input_alertmanager_replica"></a> [alertmanager\_replica](#input\_alertmanager\_replica) | Number of replicas for AlertManager | `number` | `1` | no |
 | <a name="input_alertmanager_repository"></a> [alertmanager\_repository](#input\_alertmanager\_repository) | Docker repository for Alert Manager | `string` | `"prom/alertmanager"` | no |
 | <a name="input_alertmanager_resources"></a> [alertmanager\_resources](#input\_alertmanager\_resources) | Resources for alertmanager | `map` | `{}` | no |
@@ -73,18 +62,11 @@ No modules.
 | <a name="input_alertmanager_service_account"></a> [alertmanager\_service\_account](#input\_alertmanager\_service\_account) | Name of the service account for AlertManager. Defaults to component's fully qualified name. | `string` | `""` | no |
 | <a name="input_alertmanager_service_account_annotations"></a> [alertmanager\_service\_account\_annotations](#input\_alertmanager\_service\_account\_annotations) | Annotations for the service account | `map` | `{}` | no |
 | <a name="input_alertmanager_service_annotations"></a> [alertmanager\_service\_annotations](#input\_alertmanager\_service\_annotations) | Annotations for Alertmanager service | `map` | `{}` | no |
-| <a name="input_alertmanager_service_cluster_ip"></a> [alertmanager\_service\_cluster\_ip](#input\_alertmanager\_service\_cluster\_ip) | Cluster IP for Alertmanager Service | `string` | `""` | no |
-| <a name="input_alertmanager_service_external_ips"></a> [alertmanager\_service\_external\_ips](#input\_alertmanager\_service\_external\_ips) | External IPs for Alertmanager service | `list` | `[]` | no |
-| <a name="input_alertmanager_service_labels"></a> [alertmanager\_service\_labels](#input\_alertmanager\_service\_labels) | Labels for Alertmanager service | `map` | `{}` | no |
-| <a name="input_alertmanager_service_lb_ip"></a> [alertmanager\_service\_lb\_ip](#input\_alertmanager\_service\_lb\_ip) | Load Balancer IP for Alertmanager service | `string` | `""` | no |
-| <a name="input_alertmanager_service_lb_source_ranges"></a> [alertmanager\_service\_lb\_source\_ranges](#input\_alertmanager\_service\_lb\_source\_ranges) | List of source CIDRs allowed to access the Alertmanager LB | `list` | `[]` | no |
 | <a name="input_alertmanager_service_port"></a> [alertmanager\_service\_port](#input\_alertmanager\_service\_port) | Service port for Alertmanager | `number` | `80` | no |
 | <a name="input_alertmanager_service_type"></a> [alertmanager\_service\_type](#input\_alertmanager\_service\_type) | Type of service for Alertmanager | `string` | `"ClusterIP"` | no |
 | <a name="input_alertmanager_storage_class"></a> [alertmanager\_storage\_class](#input\_alertmanager\_storage\_class) | Storage class for alertmanager PV. If set to "-", storageClassName: "", which disables dynamic provisioning | `string` | `""` | no |
-| <a name="input_alertmanager_sub_path"></a> [alertmanager\_sub\_path](#input\_alertmanager\_sub\_path) | Subdirectory of alertmanager data Persistent Volume to mount | `string` | `""` | no |
 | <a name="input_alertmanager_tag"></a> [alertmanager\_tag](#input\_alertmanager\_tag) | Tag for Alertmanager Docker Image | `string` | `"v0.16.1"` | no |
 | <a name="input_alertmanager_tolerations"></a> [alertmanager\_tolerations](#input\_alertmanager\_tolerations) | Tolerations for Alertmanager | `list` | `[]` | no |
-| <a name="input_alertmanager_volume_binding_mode"></a> [alertmanager\_volume\_binding\_mode](#input\_alertmanager\_volume\_binding\_mode) | Alertmanager data Persistent Volume Binding Mode | `string` | `""` | no |
 | <a name="input_chart_name"></a> [chart\_name](#input\_chart\_name) | Helm chart name to provision | `string` | `"prometheus"` | no |
 | <a name="input_chart_namespace"></a> [chart\_namespace](#input\_chart\_namespace) | Namespace to install the chart into | `string` | `"default"` | no |
 | <a name="input_chart_repository"></a> [chart\_repository](#input\_chart\_repository) | Helm repository for the chart | `string` | `"https://prometheus-community.github.io/helm-charts"` | no |

--- a/alertmanager.tf
+++ b/alertmanager.tf
@@ -1,0 +1,47 @@
+locals {
+  alertmanager_values = {
+    repository  = var.alertmanager_repository
+    tag         = var.alertmanager_tag
+    pull_policy = var.alertmanager_pull_policy
+
+    replica   = var.alertmanager_replica
+    resources = jsonencode(var.alertmanager_resources)
+
+    service_account             = var.alertmanager_service_account
+    service_account_annotations = jsonencode(var.alertmanager_service_account_annotations)
+
+    annotations   = jsonencode(var.alertmanager_annotations)
+    tolerations   = jsonencode(var.alertmanager_tolerations)
+    node_selector = jsonencode(var.alertmanager_node_selector)
+    affinity      = jsonencode(var.alertmanager_affinity)
+
+    security_context = coalesce(
+      var.alertmanager_security_context_json,
+      jsonencode(var.alertmanager_security_context),
+    )
+
+    extra_args = jsonencode(var.alertmanager_extra_args)
+
+    service_annotations = jsonencode(var.alertmanager_service_annotations)
+    service_port        = var.alertmanager_service_port
+    service_type        = var.alertmanager_service_type
+
+    ingress_enabled     = var.alertmanager_ingress_enabled
+    ingress_annotations = jsonencode(var.alertmanager_ingress_annotations)
+    ingress_hosts       = jsonencode(var.alertmanager_ingress_hosts)
+    ingress_tls         = jsonencode(var.alertmanager_ingress_tls)
+
+    pv_enabled      = var.alertmanager_pv_enabled
+    pv_access_modes = jsonencode(var.alertmanager_pv_access_modes)
+    pv_size         = var.alertmanager_pv_size
+    storage_class   = var.alertmanager_storage_class
+
+    config = indent(2, var.alertmanager_config)
+
+    configmap_name              = var.configmap_name
+    configmap_image_repo        = var.configmap_image_repo
+    configmap_image_tag         = var.configmap_image_tag
+    configmap_image_pull_policy = var.configmap_pull_policy
+    configmap_resources         = jsonencode(var.configmap_resources)
+  }
+}

--- a/alertmanager.tf
+++ b/alertmanager.tf
@@ -1,3 +1,19 @@
+resource "helm_release" "alertmanager" {
+  count = var.alertmanager_enable ? 1 : 0
+
+  name       = var.alertmanager_release_name
+  chart      = var.alertmanager_chart_name
+  repository = var.alertmanager_chart_repository
+  version    = var.alertmanager_chart_version
+  namespace  = var.alertmanager_chart_namespace
+
+  max_history = var.max_history
+
+  values = [
+    templatefile("${path.module}/templates/alertmanager.yaml", local.alertmanager_values),
+  ]
+}
+
 locals {
   alertmanager_values = {
     repository  = var.alertmanager_repository

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,6 @@ resource "helm_release" "prometheus" {
 
   values = [
     templatefile("${path.module}/templates/general.yaml", local.general_values),
-    templatefile("${path.module}/templates/alertmanager.yaml", local.alertmanager_values),
     templatefile("${path.module}/templates/pushgateway.yaml", local.pushgateway_values),
     templatefile("${path.module}/templates/server.yaml", local.server_values),
   ]
@@ -35,84 +34,11 @@ locals {
     extra_scrape_configs  = jsonencode(var.extra_scrape_configs)
     enable_network_policy = var.enable_network_policy
 
-    alert_relabel_configs = jsonencode(var.alert_relabel_configs)
+    pushgateway_service_account = var.pushgateway_service_account
+    server_service_account      = var.server_service_account
 
-    alertmanager_service_account  = var.alertmanager_service_account
-    node_exporter_service_account = var.node_exporter_service_account
-    pushgateway_service_account   = var.pushgateway_service_account
-    server_service_account        = var.server_service_account
-
-    alertmanager_service_account_annotations  = jsonencode(var.alertmanager_service_account_annotations)
-    node_exporter_service_account_annotations = jsonencode(var.node_exporter_service_account_annotations)
-    pushgateway_service_account_annotations   = jsonencode(var.pushgateway_service_account_annotations)
-    server_service_account_annotations        = jsonencode(var.server_service_account_annotations)
-  }
-
-  alertmanager_values = {
-    enable = var.alertmanager_enable
-
-    repository  = var.alertmanager_repository
-    tag         = var.alertmanager_tag
-    pull_policy = var.alertmanager_pull_policy
-
-    replica   = var.alertmanager_replica
-    resources = jsonencode(var.alertmanager_resources)
-
-    annotations   = jsonencode(var.alertmanager_annotations)
-    tolerations   = jsonencode(var.alertmanager_tolerations)
-    node_selector = jsonencode(var.alertmanager_node_selector)
-    affinity      = jsonencode(var.alertmanager_affinity)
-
-    security_context = coalesce(
-      var.alertmanager_security_context_json,
-      jsonencode(var.alertmanager_security_context),
-    )
-
-    priority_class_name = var.alertmanager_priority_class_name
-    extra_args          = jsonencode(var.alertmanager_extra_args)
-    extra_env           = jsonencode(var.alertmanager_extra_env)
-    extra_secret_mounts = jsonencode(var.alertmanager_extra_secret_mounts)
-
-    prefix_url = var.alertmanager_prefix_url
-    base_url   = var.alertmanager_base_url
-
-    config_map_override_name = var.alertmanager_config_map_override_name
-    config_from_secret       = var.alertmanager_config_from_secret
-    config_file_name         = var.alertmanager_config_file_name
-
-    headless_annotations = jsonencode(var.alertmanager_headless_annotations)
-    headless_labels      = jsonencode(var.alertmanager_headless_labels)
-
-    service_annotations      = jsonencode(var.alertmanager_service_annotations)
-    service_labels           = jsonencode(var.alertmanager_service_labels)
-    service_cluster_ip       = jsonencode(var.alertmanager_service_cluster_ip)
-    service_external_ips     = jsonencode(var.alertmanager_service_external_ips)
-    service_lb_ip            = jsonencode(var.alertmanager_service_lb_ip)
-    service_lb_source_ranges = jsonencode(var.alertmanager_service_lb_source_ranges)
-    service_port             = var.alertmanager_service_port
-    service_type             = var.alertmanager_service_type
-
-    ingress_enabled      = var.alertmanager_ingress_enabled
-    ingress_annotations  = jsonencode(var.alertmanager_ingress_annotations)
-    ingress_extra_labels = jsonencode(var.alertmanager_ingress_extra_labels)
-    ingress_hosts        = jsonencode(var.alertmanager_ingress_hosts)
-    ingress_tls          = jsonencode(var.alertmanager_ingress_tls)
-
-    pv_enabled          = var.alertmanager_pv_enabled
-    pv_access_modes     = jsonencode(var.alertmanager_pv_access_modes)
-    pv_annotations      = jsonencode(var.alertmanager_pv_annotations)
-    pv_existing_claim   = var.alertmanager_pv_existing_claim
-    pv_size             = var.alertmanager_pv_size
-    storage_class       = var.alertmanager_storage_class
-    volume_binding_mode = var.alertmanager_volume_binding_mode
-    sub_path            = var.alertmanager_sub_path
-
-    pod_security_policy_annotations = jsonencode(var.alertmanager_pod_security_policy_annotations)
-
-    pdb_enable          = var.alertmanager_pdb_enable
-    pdb_max_unavailable = jsonencode(var.alertmanager_pdb_max_unavailable)
-
-    alertmanager_files = indent(2, var.alertmanager_files)
+    pushgateway_service_account_annotations = jsonencode(var.pushgateway_service_account_annotations)
+    server_service_account_annotations      = jsonencode(var.server_service_account_annotations)
   }
 
   pushgateway_values = {

--- a/node_exporter.tf
+++ b/node_exporter.tf
@@ -33,6 +33,9 @@ locals {
     labels        = jsonencode(var.node_exporter_labels)
     node_selector = jsonencode(var.node_exporter_node_selector)
 
+    service_account             = var.node_exporter_service_account
+    service_account_annotations = jsonencode(var.node_exporter_service_account_annotations)
+
     security_context = coalesce(
       var.node_exporter_security_context_json,
       jsonencode(var.node_exporter_security_context),

--- a/templates/alertmanager.yaml
+++ b/templates/alertmanager.yaml
@@ -1,252 +1,85 @@
-alertmanager:
-  ## If false, alertmanager will not be installed
-  ##
-  enabled: ${enable}
+replicaCount: ${replica}
 
-  ## alertmanager container name
-  ##
-  name: alertmanager
+image:
+  repository: ${repository}
+  pullPolicy: ${pull_policy}
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ${tag}
 
-  ## alertmanager container image
+extraArgs: ${extra_args}
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: ${service_account_annotations}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ${service_account}
+
+podSecurityContext: ${security_context}
+
+service:
+  annotations: ${service_annotations}
+  type: ${service_type}
+  port: ${service_port}
+  # if you want to force a specific nodePort. Must be use with service.type=NodePort
+  # nodePort:
+
+ingress:
+  enabled: ${ingress_enabled}
+  annotations: ${ingress_annotations}
+  hosts: ${ingress_hosts}
+  tls: ${ingress_tls}
+
+resources: ${resources}
+
+nodeSelector: ${node_selector}
+
+tolerations: ${tolerations}
+
+affinity: ${affinity}
+
+podAnnotations: ${annotations}
+
+persistence:
+  enabled: ${pv_enabled}
+  ## Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ## set, choosing the default provisioner.
+  ##
+  storageClass: ${storage_class}
+  accessModes: ${pv_access_modes}
+  size: ${pv_size}
+
+config:
+  ${config}
+
+## Monitors ConfigMap changes and POSTs to a URL
+## Ref: https://github.com/jimmidyson/configmap-reload
+##
+configmapReload:
+  ## If false, the configmap-reload container will not be deployed
+  ##
+  enabled: true
+
+  ## configmap-reload container name
+  ##
+  name: ${configmap_name}
+
+  ## configmap-reload container image
   ##
   image:
-    repository: ${repository}
-    tag: ${tag}
-    pullPolicy: ${pull_policy}
+    repository: ${configmap_image_repo}
+    tag: ${configmap_image_tag}
+    pullPolicy: ${configmap_image_pull_policy}
 
-  ## alertmanager priorityClassName
-  ##
-  priorityClassName: ${priority_class_name}
-
-  ## Additional alertmanager container arguments
-  ##
-  extraArgs: ${extra_args}
-
-  ## The URL prefix at which the container can be accessed. Useful in the case the '-web.external-url' includes a slug
-  ## so that the various internal URLs are still able to access as they are in the default case.
-  ## (Optional)
-  prefixURL: ${prefix_url}
-
-  ## External URL which can access alertmanager
-  ## Maybe same with Ingress host name
-  baseURL: ${base_url}
-
-  ## Additional alertmanager container environment variable
-  ## For instance to add a http_proxy
-  ##
-  extraEnv: ${extra_env}
-
-  ## Additional alertmanager Secret mounts
-  # Defines additional mounts with secrets. Secrets must be manually created in the namespace.
-  extraSecretMounts: ${extra_secret_mounts}
-    # - name: secret-files
-    #   mountPath: /etc/secrets
-    #   subPath: ""
-    #   secretName: alertmanager-secret-files
-    #   readOnly: true
-
-
-  ## ConfigMap override where fullname is {{.Release.Name}}-{{.Values.alertmanager.configMapOverrideName}}
-  ## Defining configMapOverrideName will cause templates/alertmanager-configmap.yaml
-  ## to NOT generate a ConfigMap resource
-  ##
-  configMapOverrideName: ${config_map_override_name}
-
-  ## The name of a secret in the same kubernetes namespace which contains the Alertmanager config
-  ## Defining configFromSecret will cause templates/alertmanager-configmap.yaml
-  ## to NOT generate a ConfigMap resource
-  ##
-  configFromSecret: ${config_from_secret}
-
-  ## The configuration file name to be loaded to alertmanager
-  ## Must match the key within configuration loaded from ConfigMap/Secret
-  ##
-  configFileName: ${config_file_name}
-
-  ingress:
-    ## If true, alertmanager Ingress will be created
-    ##
-    enabled: ${ingress_enabled}
-
-    ## alertmanager Ingress annotations
-    ##
-    annotations: ${ingress_annotations}
-    #   kubernetes.io/ingress.class: nginx
-    #   kubernetes.io/tls-acme: 'true'
-
-    ## alertmanager Ingress additional labels
-    ##
-    extraLabels: ${ingress_extra_labels}
-
-    ## alertmanager Ingress hostnames with optional path
-    ## Must be provided if Ingress is enabled
-    ##
-    hosts: ${ingress_hosts}
-    #   - alertmanager.domain.com
-    #   - domain.com/alertmanager
-
-    ## alertmanager Ingress TLS configuration
-    ## Secrets must be manually created in the namespace
-    ##
-    tls: ${ingress_tls}
-    #   - secretName: prometheus-alerts-tls
-    #     hosts:
-    #       - alertmanager.domain.com
-
-  ## Alertmanager Deployment Strategy type
-  # strategy:
-  #   type: Recreate
-
-  ## Node tolerations for alertmanager scheduling to nodes with taints
-  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-  ##
-  tolerations: ${tolerations}
-    # - key: "key"
-    #   operator: "Equal|Exists"
-    #   value: "value"
-    #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
-
-  ## Node labels for alertmanager pod assignment
-  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
-  ##
-  nodeSelector: ${node_selector}
-
-  ## Pod affinity
-  ##
-  affinity: ${affinity}
-
-  ## PodDisruptionBudget settings
-  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
-  ##
-  podDisruptionBudget:
-    enabled: ${pdb_enable}
-    maxUnavailable: ${pdb_max_unavailable}
-
-  ## Use an alternate scheduler, e.g. "stork".
-  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
-  ##
-  # schedulerName:
-
-  persistentVolume:
-    ## If true, alertmanager will create/use a Persistent Volume Claim
-    ## If false, use emptyDir
-    ##
-    enabled: ${pv_enabled}
-
-    ## alertmanager data Persistent Volume access modes
-    ## Must match those of existing PV or dynamic provisioner
-    ## Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-    ##
-    accessModes: ${pv_access_modes}
-
-    ## alertmanager data Persistent Volume Claim annotations
-    ##
-    annotations: ${pv_annotations}
-
-    ## alertmanager data Persistent Volume existing claim name
-    ## Requires alertmanager.persistentVolume.enabled: true
-    ## If defined, PVC must be created manually before volume will be bound
-    existingClaim: ${pv_existing_claim}
-
-    ## alertmanager data Persistent Volume mount root path
-    ##
-    mountPath: /data
-
-    ## alertmanager data Persistent Volume size
-    ##
-    size: ${pv_size}
-
-    ## alertmanager data Persistent Volume Storage Class
-    ## If defined, storageClassName: <storageClass>
-    ## If set to "-", storageClassName: "", which disables dynamic provisioning
-    ## If undefined (the default) or set to null, no storageClassName spec is
-    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-    ##   GKE, AWS & OpenStack)
-    ##
-    storageClass: ${storage_class}
-
-    ## alertmanager data Persistent Volume Binding Mode
-    ## If defined, volumeBindingMode: <volumeBindingMode>
-    ## If undefined (the default) or set to null, no volumeBindingMode spec is
-    ##   set, choosing the default mode.
-    ##
-    volumeBindingMode: ${volume_binding_mode}
-
-    ## Subdirectory of alertmanager data Persistent Volume to mount
-    ## Useful if the volume's root directory is not empty
-    ##
-    subPath: "${sub_path}"
-
-  ## Annotations to be added to alertmanager pods
-  ##
-  podAnnotations: ${annotations}
-
-  ## Use a StatefulSet if replicaCount needs to be greater than 1 (see below)
-  ##
-  replicaCount: ${replica}
-
-  statefulSet:
-    ## If true, use a statefulset instead of a deployment for pod management.
-    ## This allows to scale replicas to more than 1 pod
-    ##
-    enabled: true
-
-    podManagementPolicy: OrderedReady
-
-    ## Alertmanager headless service to use for the statefulset
-    ##
-    headless:
-      annotations: ${headless_annotations}
-      labels: ${headless_labels}
-
-      ## Enabling peer mesh service end points for enabling the HA alert manager
-      ## Ref: https://github.com/prometheus/alertmanager/blob/master/README.md
-      enableMeshPeer: ${replica > 0 ? "true" : "false"}
-
-      servicePort: 80
-
-  ## alertmanager resource requests and limits
+  ## configmap-reload resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
-  resources: ${resources}
-    # limits:
-    #   cpu: 10m
-    #   memory: 32Mi
-    # requests:
-    #   cpu: 10m
-    #   memory: 32Mi
+  resources: ${configmap_resources}
 
-  ## Security context to be added to alertmanager pods
-  ##
-  securityContext: ${security_context}
-
-  service:
-    annotations: ${service_annotations}
-    labels: ${service_labels}
-    clusterIP: ${service_cluster_ip}
-
-    ## List of IP addresses at which the alertmanager service is available
-    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
-    ##
-    externalIPs: ${service_external_ips}
-
-    loadBalancerIP: ${service_lb_ip}
-    loadBalancerSourceRanges: ${service_lb_source_ranges}
-    servicePort: ${service_port}
-    # nodePort: 30000
-    type: ${service_type}
-
-  podSecurityPolicy:
-    annotations: ${pod_security_policy_annotations}
-      ## Specify pod annotations
-      ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
-      ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
-      ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#sysctl
-      ##
-      # seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
-      # seccomp.security.alpha.kubernetes.io/defaultProfileName: 'docker/default'
-      # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
-
-
-alertmanagerFiles:
-  ${alertmanager_files}
+templates: {}
+#   alertmanager.tmpl: |-

--- a/templates/general.yaml
+++ b/templates/general.yaml
@@ -10,13 +10,9 @@ imagePullSecrets: ${image_pull_secrets}
 ##
 serviceAccounts:
   alertmanager:
-    create: true
-    name: ${alertmanager_service_account}
-    annotations: ${alertmanager_service_account_annotations}
+    create: false
   nodeExporter:
-    create: true
-    name: ${node_exporter_service_account}
-    annotations: ${node_exporter_service_account_annotations}
+    create: false
   pushgateway:
     create: true
     name: ${pushgateway_service_account}
@@ -69,43 +65,7 @@ configmapReload:
     resources: ${configmap_resources}
 
   alertmanager:
-    ## If false, the configmap-reload container will not be deployed
-    ##
-    enabled: true
-
-    ## configmap-reload container name
-    ##
-    name: ${configmap_name}
-
-    ## configmap-reload container image
-    ##
-    image:
-      repository: ${configmap_image_repo}
-      tag: ${configmap_image_tag}
-      pullPolicy: ${configmap_image_pull_policy}
-
-    ## Additional configmap-reload container arguments
-    ##
-    extraArgs: ${configmap_extra_args}
-    ## Additional configmap-reload volume directories
-    ##
-    extraVolumeDirs: ${configmap_extra_args}
-
-
-    ## Additional configmap-reload mounts
-    ##
-    extraConfigmapMounts: ${configmap_extra_volumes}
-      # - name: prometheus-alerts
-      #   mountPath: /etc/alerts.d
-      #   subPath: ""
-      #   configMap: prometheus-alerts
-      #   readOnly: true
-
-
-    ## configmap-reload resource requests and limits
-    ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
-    ##
-    resources: ${configmap_resources}
+    enabled: false
 
 # adds additional scrape configs to prometheus.yml
 # must be a string so you have to add a | after extraScrapeConfigs:
@@ -126,14 +86,6 @@ extraScrapeConfigs: ${extra_scrape_configs}
   #     - target_label: __address__
   #       replacement: prometheus-blackbox-exporter:9115
 
-# Adds option to add alert_relabel_configs to avoid duplicate alerts in alertmanager
-# useful in H/A prometheus with different external labels but the same alerts
-alertRelabelConfigs: ${alert_relabel_configs}
-  # alert_relabel_configs:
-  # - source_labels: [dc]
-  #   regex: (.+)\d+
-  #   target_label: dc
-
 networkPolicy:
   ## Enable creation of NetworkPolicy resources.
   ##
@@ -145,6 +97,10 @@ kubeStateMetrics:
   ##
   enabled: false
 
-# Disable component
+# Use the standalone Node Exporter chart
 nodeExporter:
+  enabled: false
+
+# Use the standalone Alertmanager chart
+alertmanager:
   enabled: false

--- a/templates/node_exporter.yaml
+++ b/templates/node_exporter.yaml
@@ -39,8 +39,8 @@ serviceAccount:
   create: true
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
-  name:
-  annotations: {}
+  name: ${service_account}
+  annotations: ${service_account_annotations}
   imagePullSecrets: []
 
 securityContext: ${security_context}

--- a/variables.tf
+++ b/variables.tf
@@ -161,7 +161,7 @@ variable "alertmanager_repository" {
 
 variable "alertmanager_tag" {
   description = "Tag for Alertmanager Docker Image"
-  default     = "v0.16.1"
+  default     = "v0.22.2"
 }
 
 variable "alertmanager_pull_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -145,8 +145,33 @@ variable "configmap_resources" {
 # Alertmanager
 ################################
 variable "alertmanager_enable" {
-  description = "Enable Alert manager"
+  description = "Enable Alertmanager"
   default     = "true"
+}
+
+variable "alertmanager_release_name" {
+  description = "Helm release name for Alertmanager"
+  default     = "alertmanager"
+}
+
+variable "alertmanager_chart_name" {
+  description = "Helm Alertmanager chart name to provision"
+  default     = "alertmanager"
+}
+
+variable "alertmanager_chart_repository" {
+  description = "Helm repository for the Alertmanager chart"
+  default     = "https://prometheus-community.github.io/helm-charts"
+}
+
+variable "alertmanager_chart_version" {
+  description = "Version of Alertmanager chart to install. Set to empty to install the latest version"
+  default     = ""
+}
+
+variable "alertmanager_chart_namespace" {
+  description = "Namespace to install the Alertmanager chart into"
+  default     = "default"
 }
 
 variable "alertmanager_repository" {

--- a/variables.tf
+++ b/variables.tf
@@ -103,11 +103,6 @@ variable "server_service_account_annotations" {
   default     = {}
 }
 
-variable "alert_relabel_configs" {
-  description = "Adds option to add alert_relabel_configs to avoid duplicate alerts in alertmanager useful in H/A prometheus with different external labels but the same alerts"
-  default     = {}
-}
-
 ################################
 # ConfigMap Reload
 ################################
@@ -169,49 +164,9 @@ variable "alertmanager_pull_policy" {
   default     = "IfNotPresent"
 }
 
-variable "alertmanager_priority_class_name" {
-  description = "Priority Class Name for Alertmanager pods"
-  default     = ""
-}
-
 variable "alertmanager_extra_args" {
   description = "Extra arguments for Alertmanager container"
   default     = {}
-}
-
-variable "alertmanager_extra_env" {
-  description = "Extra environment variables for Alertmanager container"
-  default     = {}
-}
-
-variable "alertmanager_extra_secret_mounts" {
-  description = "Defines additional mounts with secrets. Secrets must be manually created in the namespace."
-  default     = []
-}
-
-variable "alertmanager_prefix_url" {
-  description = "The URL prefix at which the container can be accessed. Useful in the case the '-web.external-url' includes a slug so that the various internal URLs are still able to access as they are in the default case."
-  default     = ""
-}
-
-variable "alertmanager_base_url" {
-  description = "External URL which can access alertmanager"
-  default     = "/"
-}
-
-variable "alertmanager_config_map_override_name" {
-  description = "ConfigMap override where fullname is {{.Release.Name}}-{{.Values.alertmanager.configMapOverrideName} Defining configMapOverrideName will cause templates/alertmanager-configmap.yaml to NOT generate a ConfigMap resource"
-  default     = ""
-}
-
-variable "alertmanager_config_from_secret" {
-  description = "The name of a secret in the same kubernetes namespace which contains the Alertmanager config Defining configFromSecret will cause templates/alertmanager-configmap.yaml to NOT generate a ConfigMap resource"
-  default     = ""
-}
-
-variable "alertmanager_config_file_name" {
-  description = "The configuration file name to be loaded to alertmanager Must match the key within configuration loaded from ConfigMap/Secret"
-  default     = "alertmanager.yml"
 }
 
 variable "alertmanager_ingress_enabled" {
@@ -221,11 +176,6 @@ variable "alertmanager_ingress_enabled" {
 
 variable "alertmanager_ingress_annotations" {
   description = "Annotations for Alertmanager ingress"
-  default     = {}
-}
-
-variable "alertmanager_ingress_extra_labels" {
-  description = "Additional labels for Alertmanager ingress"
   default     = {}
 }
 
@@ -272,16 +222,6 @@ variable "alertmanager_pv_access_modes" {
   ]
 }
 
-variable "alertmanager_pv_annotations" {
-  description = "Annotations for Alertmanager PV"
-  default     = {}
-}
-
-variable "alertmanager_pv_existing_claim" {
-  description = "Use an existing PV claim for alertmanager"
-  default     = ""
-}
-
 variable "alertmanager_pv_size" {
   description = "alertmanager data Persistent Volume size"
   default     = "2Gi"
@@ -292,29 +232,9 @@ variable "alertmanager_storage_class" {
   default     = ""
 }
 
-variable "alertmanager_volume_binding_mode" {
-  description = "Alertmanager data Persistent Volume Binding Mode"
-  default     = ""
-}
-
-variable "alertmanager_sub_path" {
-  description = "Subdirectory of alertmanager data Persistent Volume to mount"
-  default     = ""
-}
-
 variable "alertmanager_replica" {
   description = "Number of replicas for AlertManager"
   default     = 1
-}
-
-variable "alertmanager_headless_annotations" {
-  description = "Annotations for alertmanager StatefulSet headless service"
-  default     = {}
-}
-
-variable "alertmanager_headless_labels" {
-  description = "Labels for alertmanager StatefulSet headless service"
-  default     = {}
 }
 
 variable "alertmanager_resources" {
@@ -344,31 +264,6 @@ variable "alertmanager_service_annotations" {
   default     = {}
 }
 
-variable "alertmanager_service_labels" {
-  description = "Labels for Alertmanager service"
-  default     = {}
-}
-
-variable "alertmanager_service_cluster_ip" {
-  description = "Cluster IP for Alertmanager Service"
-  default     = ""
-}
-
-variable "alertmanager_service_external_ips" {
-  description = "External IPs for Alertmanager service"
-  default     = []
-}
-
-variable "alertmanager_service_lb_ip" {
-  description = "Load Balancer IP for Alertmanager service"
-  default     = ""
-}
-
-variable "alertmanager_service_lb_source_ranges" {
-  description = "List of source CIDRs allowed to access the Alertmanager LB"
-  default     = []
-}
-
 variable "alertmanager_service_port" {
   description = "Service port for Alertmanager"
   default     = 80
@@ -379,45 +274,27 @@ variable "alertmanager_service_type" {
   default     = "ClusterIP"
 }
 
-variable "alertmanager_pod_security_policy_annotations" {
-  description = "PodSecurityPolicy annotations for alertmanager"
-  default = {
-    "seccomp.security.alpha.kubernetes.io/allowedProfileNames" = "docker/default,runtime/default"
-    "apparmor.security.beta.kubernetes.io/allowedProfileNames" = "runtime/default"
-    "seccomp.security.alpha.kubernetes.io/defaultProfileName"  = "runtime/default"
-    "apparmor.security.beta.kubernetes.io/defaultProfileName"  = "runtime/default"
-  }
-}
-
-variable "alertmanager_pdb_enable" {
-  description = "Enable PDB"
-  default     = true
-}
-
-variable "alertmanager_pdb_max_unavailable" {
-  description = "Max unavailable pods for Alertmanager"
-  default     = 1
-}
-
-variable "alertmanager_files" {
+variable "alertmanager_config" {
   description = "Additional ConfigMap entries for Alertmanager in YAML string"
 
   default = <<EOF
-alertmanager.yml:
-  global: {}
-    # slack_api_url: ''
+global: {}
+  # slack_api_url: ''
 
-  receivers:
-    - name: default-receiver
-      # slack_configs:
-      #  - channel: '@you'
-      #    send_resolved: true
+templates:
+  - '/etc/alertmanager/*.tmpl'
 
-  route:
-    group_wait: 10s
-    group_interval: 5m
-    receiver: default-receiver
-    repeat_interval: 3h
+receivers:
+  - name: default-receiver
+    # slack_configs:
+    #  - channel: '@you'
+    #    send_resolved: true
+
+route:
+  group_wait: 10s
+  group_interval: 5m
+  receiver: default-receiver
+  repeat_interval: 3h
 EOF
 
 }

--- a/variables.tf
+++ b/variables.tf
@@ -291,6 +291,7 @@ variable "alertmanager_service_type" {
 
 variable "alertmanager_config" {
   description = "Additional ConfigMap entries for Alertmanager in YAML string"
+  sensitive   = true
 
   default = <<EOF
 global: {}

--- a/variables.tf
+++ b/variables.tf
@@ -53,18 +53,8 @@ variable "enable_network_policy" {
   default     = "false"
 }
 
-variable "alertmanager_service_account" {
-  description = "Name of the service account for AlertManager. Defaults to component's fully qualified name."
-  default     = ""
-}
-
 variable "kube_state_metrics_service_account" {
   description = "Name of the service account for kubeStateMetrics. Defaults to component's fully qualified name."
-  default     = ""
-}
-
-variable "node_exporter_service_account" {
-  description = "Name of the service account for nodeExporter. Defaults to component's fully qualified name."
   default     = ""
 }
 
@@ -78,17 +68,7 @@ variable "server_service_account" {
   default     = ""
 }
 
-variable "alertmanager_service_account_annotations" {
-  description = "Annotations for the service account"
-  default     = {}
-}
-
 variable "kube_state_metrics_service_account_annotations" {
-  description = "Annotations for the service account"
-  default     = {}
-}
-
-variable "node_exporter_service_account_annotations" {
   description = "Annotations for the service account"
   default     = {}
 }
@@ -187,6 +167,16 @@ variable "alertmanager_tag" {
 variable "alertmanager_pull_policy" {
   description = "Image pull policy for Alertmanager"
   default     = "IfNotPresent"
+}
+
+variable "alertmanager_service_account" {
+  description = "Name of the service account for AlertManager. Defaults to component's fully qualified name."
+  default     = ""
+}
+
+variable "alertmanager_service_account_annotations" {
+  description = "Annotations for the service account"
+  default     = {}
 }
 
 variable "alertmanager_extra_args" {
@@ -588,6 +578,16 @@ variable "node_exporter_tag" {
 variable "node_exporter_pull_policy" {
   description = "Image pull policy for Node Exporter"
   default     = "IfNotPresent"
+}
+
+variable "node_exporter_service_account" {
+  description = "Name of the service account for nodeExporter. Defaults to component's fully qualified name."
+  default     = ""
+}
+
+variable "node_exporter_service_account_annotations" {
+  description = "Annotations for the service account"
+  default     = {}
 }
 
 variable "node_exporter_enable_pod_security_policy" {


### PR DESCRIPTION
Switch to use the standalone official alertmanager chart.

Also fix SA name and annotation configuration on the node exporter chart.