### PR TITLE
Fix Values.namespaces type in KSM

### DIFF
--- a/templates/kube_state_metrics.yaml
+++ b/templates/kube_state_metrics.yaml
@@ -166,8 +166,8 @@ kubeconfig:
   # base64 encoded kube-config file
   secret:
 
-# Namespaces to be enabled for collecting resources. By default all namespaces are collected.
-namespaces: ${collection_namespace}
+# Comma-separated list of namespaces to be enabled for collecting resources. By default all namespaces are collected.
+namespaces: "${collection_namespace}"
 
 ## Override the deployment namespace
 ##


### PR DESCRIPTION
Got this error when planning the module:

```
 Error: error running dry run for a diff: template: kube-state-metrics/templates/role.yaml:2:28: executing "kube-state-metrics/templates/role.yaml" at <.Values.namespaces>: wrong type for value; expected string; got interface {}
```

`.Values.namespace` can not set `null`, should be `""`.
Reference PR https://github.com/prometheus-community/helm-charts/pull/953